### PR TITLE
Gitpod fixes

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+image: node:11.10.1-alpine
+ports:
+- port: 8080

--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "0.2.0",
+  "configurations": [
+       {
+      "type": "node",
+      "request": "launch",
+      "name": "Run All Tests",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "internalConsoleOptions": "neverOpen",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      },
+    },
+  ]
+}
+


### PR DESCRIPTION
This PR fixes issues that are cause by moving to GitPod(GP). Currently no way of getting hot module replacement to work as i cant figure out away to map the ephemeral port. Other the this this PR addresses

* Upgrading and pinning the base docker image (node:11.10.1-alpine)
* Adding a debug runner of Jest. This will allow them to debug failing test
* Note enforcing host validation (this was actually done on commit 1c706b13be06794cfcf5266573eb1ea29590f5f3)

Still need to discuss what is happening with other levels ups before merging to master.